### PR TITLE
Add Donate button to Info screen

### DIFF
--- a/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
+++ b/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
@@ -42,6 +42,7 @@ import org.wxyc.wxycapp.ui.theme.BlueButton
 import org.wxyc.wxycapp.ui.theme.GreenButton
 import org.wxyc.wxycapp.ui.theme.RedButton
 import org.wxyc.wxycapp.ui.theme.WXYCTheme
+import org.wxyc.wxycapp.ui.theme.YellowButton
 
 @Composable
 fun InfoScreen(
@@ -123,6 +124,21 @@ fun InfoScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text(text = "Send us feedback on the app", color = Color.White)
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            Button(
+                onClick = {
+                    val donateIntent = Intent(Intent.ACTION_VIEW).apply {
+                        data = Uri.parse("https://wxyc.org/donate")
+                    }
+                    context.startActivity(donateIntent)
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = YellowButton),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = "Donate", color = Color.Black)
             }
         }
     }

--- a/app/src/main/java/org/wxyc/wxycapp/ui/theme/Theme.kt
+++ b/app/src/main/java/org/wxyc/wxycapp/ui/theme/Theme.kt
@@ -16,6 +16,7 @@ val SoftWhite = Color(0xFFF3F4F5)
 val GreenButton = Color(0xFF34C759)
 val BlueButton = Color(0xFF007AFF)
 val RedButton = Color(0xFFFF0000)
+val YellowButton = Color(0xFFFFCC00)
 
 private val DarkColorScheme = darkColorScheme(
     primary = BlueButton,


### PR DESCRIPTION
Adds a fourth button to the Info screen's button column, below Dial a DJ / Make a Request / Send us feedback. Tapping it fires a plain `Intent(Intent.ACTION_VIEW)` at `https://wxyc.org/donate`, handing off to the user's browser. The app never sees or processes a payment — it only links out.

## Scope decision (settled during planning)

The URL is hardcoded for v1. This repo has no `/config` client at all (`NetworkModule.kt` builds Retrofit only for Discogs/iTunes/Spotify) and no `androidx.browser` dependency, so remote configuration and Custom Tabs would each be a real new subsystem rather than a button. The accepted cost is that retargeting the link requires a Play Store release, unlike iOS, which gets remote config in its slice. The mitigation is the choice of destination: the button points at `wxyc.org/donate`, the stable org-owned page, rather than directly at a vendor page — so the actual donation destination stays retargetable server-side without touching the app. A config client plus Custom Tabs is a follow-up ticket if Android ever needs the kill switch.

## Contrast

The Donate label is black rather than white. White on the `#FFCC00` container measures 1.51:1, far under the 4.5:1 WCAG AA threshold and worse than every sibling button (red 4.00:1, blue 4.02:1, green 2.22:1); black on the same yellow measures 13.89:1. The container keeps the Apple system-yellow value, so the palette stays consistent with `GreenButton` (systemGreen) and `BlueButton` (systemBlue) — only the ink changes.

## Tests

None, by design rather than oversight. `app/src/test/java/org/wxyc/wxycapp/` covers only `data/`; none of the three existing buttons has a test, and an `ACTION_VIEW` intent launch matches that pattern exactly. No new dependencies. `assembleDebug`, `test`, and `lint` all pass locally.

## Sequencing

`https://wxyc.org/donate` currently returns 404 — the page ships in WXYC/website#220. There is no GitHub-side dependency between the two, but the page PR should be deployed before this app change reaches users.

Closes #27

## Related

Sibling slices of the WXYC donation-button initiative (contract to backend to clients):

- WXYC/wxyc-shared#338 — contract: `AppConfig.donateUrl` + `donateEnabled`
- WXYC/Backend-Service#2111 — `GET /config` serves both fields (dark)
- WXYC/wxyc-ios-64#912 — iOS Donate row + `/config` launch plumbing (implemented in WXYC/wxyc-ios-64#913)
- WXYC/website#220 — the wxyc.org/donate page this button targets
