### PR TITLE
Make Info screen button column scrollable

### DIFF
--- a/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
+++ b/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -66,7 +68,8 @@ fun InfoScreen(
         contentAlignment = Alignment.Center
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.verticalScroll(rememberScrollState())
         ) {
             Text(
                 text = "You're tuned in.",


### PR DESCRIPTION
## Problem

The button `Column` on the Info screen has no `verticalScroll`, so its content overflows and clips at accessibility font scales (~1.3+) or large display size. The bottommost buttons become unreachable.

## Fix

Add `Modifier.verticalScroll(rememberScrollState())` to the button Column. Scrolling only engages on overflow, so layout is unchanged at default font scale.

Closes #30