### PR TITLE
Wrap Info screen intent launches in a safe helper

### DIFF
--- a/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
+++ b/app/src/main/java/org/wxyc/wxycapp/ui/screens/InfoScreen.kt
@@ -42,6 +42,7 @@ import org.wxyc.wxycapp.ui.theme.BlueButton
 import org.wxyc.wxycapp.ui.theme.GreenButton
 import org.wxyc.wxycapp.ui.theme.RedButton
 import org.wxyc.wxycapp.ui.theme.WXYCTheme
+import org.wxyc.wxycapp.util.launchIntentSafely
 
 @Composable
 fun InfoScreen(
@@ -92,7 +93,7 @@ fun InfoScreen(
                     val dialIntent = Intent(Intent.ACTION_DIAL).apply {
                         data = Uri.parse("tel:9199628989")
                     }
-                    context.startActivity(dialIntent)
+                    launchIntentSafely(context, dialIntent, "No phone app found")
                 },
                 colors = ButtonDefaults.buttonColors(containerColor = GreenButton),
                 modifier = Modifier.fillMaxWidth()
@@ -117,7 +118,7 @@ fun InfoScreen(
                     val feedbackIntent = Intent(Intent.ACTION_SENDTO).apply {
                         data = Uri.parse("mailto:feedback@wxyc.org?subject=Feedback%20on%20the%20WXYC%20Android%20app")
                     }
-                    context.startActivity(feedbackIntent)
+                    launchIntentSafely(context, feedbackIntent, "No email app found")
                 },
                 colors = ButtonDefaults.buttonColors(containerColor = RedButton),
                 modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/org/wxyc/wxycapp/util/IntentUtils.kt
+++ b/app/src/main/java/org/wxyc/wxycapp/util/IntentUtils.kt
@@ -1,0 +1,14 @@
+package org.wxyc.wxycapp.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+
+fun launchIntentSafely(context: Context, intent: Intent, fallbackMessage: String) {
+    try {
+        context.startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Toast.makeText(context, fallbackMessage, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/test/java/org/wxyc/wxycapp/util/IntentUtilsTest.kt
+++ b/app/src/test/java/org/wxyc/wxycapp/util/IntentUtilsTest.kt
@@ -1,0 +1,56 @@
+package org.wxyc.wxycapp.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.MockedStatic
+
+class IntentUtilsTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockIntent: Intent
+    private lateinit var toastMock: MockedStatic<Toast>
+    private lateinit var mockToast: Toast
+
+    @Before
+    fun setUp() {
+        mockContext = mock(Context::class.java)
+        mockIntent = mock(Intent::class.java)
+        mockToast = mock(Toast::class.java)
+        toastMock = mockStatic(Toast::class.java)
+        toastMock.`when`<Toast> {
+            Toast.makeText(mockContext, "fallback message", Toast.LENGTH_SHORT)
+        }.thenReturn(mockToast)
+    }
+
+    @After
+    fun tearDown() {
+        toastMock.close()
+    }
+
+    @Test
+    fun `launches the intent when a handler exists`() {
+        launchIntentSafely(mockContext, mockIntent, "fallback message")
+
+        verify(mockContext).startActivity(mockIntent)
+        toastMock.verifyNoInteractions()
+    }
+
+    @Test
+    fun `shows the fallback message instead of crashing when no handler exists`() {
+        doThrow(ActivityNotFoundException::class.java).`when`(mockContext).startActivity(mockIntent)
+
+        launchIntentSafely(mockContext, mockIntent, "fallback message")
+
+        verify(mockToast).show()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `launchIntentSafely(context, intent, fallbackMessage)`, a small shared helper that wraps `context.startActivity()` in a try/catch for `ActivityNotFoundException` and shows a toast instead of crashing.
- Routes the Dial a DJ and Send feedback call sites in `InfoScreen.kt` through the helper. No change to intent construction or button behavior on the happy path.

The Donate button call site (#27 / #28) isn't on `master` yet, so it isn't in scope for this diff — the base branch here only has the two existing call sites. Whichever PR lands second should route the Donate intent through `launchIntentSafely` too.

Closes #29

## Test plan
- [x] `IntentUtilsTest` (new): verifies the intent launches normally when a handler exists, and that a toast fires instead of crashing when `startActivity` throws `ActivityNotFoundException`
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :app:lintDebug` passes